### PR TITLE
Add Docker

### DIFF
--- a/collaboration-service/.dockerignore
+++ b/collaboration-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/collaboration-service/Dockerfile
+++ b/collaboration-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8003
+CMD ["node", "index.js"]

--- a/communication-service/.dockerignore
+++ b/communication-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/communication-service/Dockerfile
+++ b/communication-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8002
+CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+version: "3.8"
+
+services:
+  frontend:
+    container_name: frontend
+    build:
+      context: ./frontend
+    ports:
+      - 3000:3000
+    depends_on:
+      [user-service, matching-service, communication-service, collaboration-service, question-service]
+
+  user-service:
+    container_name: user-service
+    build:
+      context: ./user-service
+    ports:
+      - 8000:8000
+    depends_on:
+      [mongo-user, redis]
+
+  matching-service:
+    container_name: matching-service
+    build:
+      context: ./matching-service
+    ports:
+      - 8001:8001
+
+  communication-service:
+    container_name: communication-service
+    build:
+      context: ./communication-service
+    ports:
+      - 8002:8002
+
+  collaboration-service:
+    container_name: collaboration-service
+    build:
+      context: ./collaboration-service
+    ports:
+      - 8003:8003
+
+  question-service:
+    container_name: question-service
+    build:
+      context: ./question-service
+    ports:
+      - 8004:8004
+    depends_on:
+      - mongo-question
+
+  mongo-user:
+    container_name: mongo-user
+    image: mongo
+    ports:
+      - 27017:27017
+    volumes:
+      - mongo-user-volume:/data/db
+
+  mongo-question:
+    container_name: mongo-question
+    image: mongo
+    ports:
+      - 27018:27017
+    volumes:
+      - mongo-question-volume:/data/db
+
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-volume:/data
+
+volumes:
+  mongo-user-volume:
+  mongo-question-volume:
+  redis-volume:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/matching-service/.dockerignore
+++ b/matching-service/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+*.sqlite

--- a/matching-service/Dockerfile
+++ b/matching-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8001
+CMD ["node", "index.js"]

--- a/question-service/.dockerignore
+++ b/question-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/question-service/.env.sample
+++ b/question-service/.env.sample
@@ -1,0 +1,7 @@
+# If ENV=PROD, DB_CLOUD_URI is used
+# If ENV=DEV, DB_LOCAL_URI or DB_DOCKER_URI is used
+ENV=DEV
+
+DB_CLOUD_URI=
+DB_LOCAL_URI=
+DB_DOCKER_URI=mongodb://mongo-question:27017/peerprep

--- a/question-service/Dockerfile
+++ b/question-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8004
+CMD ["node", "index.js"]

--- a/question-service/model/repository.js
+++ b/question-service/model/repository.js
@@ -5,11 +5,13 @@ import questionModel from "./question-model.js";
 //Set up mongoose connection
 import mongoose from 'mongoose';
 
-let mongoDB = process.env.ENV == "PROD" ? process.env.DB_CLOUD_URI : process.env.DB_LOCAL_URI;
+const mongoDB = process.env.ENV == 'PROD'
+  ? process.env.DB_CLOUD_URI
+  : process.env.DB_LOCAL_URI || process.env.DB_DOCKER_URI;
 
 mongoose.connect(mongoDB, { useNewUrlParser: true , useUnifiedTopology: true});
 
-let db = mongoose.connection;
+const db = mongoose.connection;
 db.on('error', console.error.bind(console, 'MongoDB connection error:'));
 
 export async function getAllQuestions() {

--- a/user-service/.dockerignore
+++ b/user-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/user-service/.env.sample
+++ b/user-service/.env.sample
@@ -1,12 +1,14 @@
-# To use a cloud database, set ENV=PROD and fill in the DB_CLOUD_URI
-# To use a local database, set ENV=LOCAL and fill in the DB_LOCAL_URI
-ENV=
+# If ENV=PROD, DB_CLOUD_URI, and REDIS_CLOUD_HOST, REDIS_CLOUD_PORT, REDIS_CLOUD_PASSWORD are used
+# If ENV=DEV, DB_LOCAL_URI or DB_DOCKER_URI, and REDIS_DOCKER_URL are used
+ENV=DEV
+
 DB_CLOUD_URI=
 DB_LOCAL_URI=
+DB_DOCKER_URI=mongodb://mongo-user:27017/peerprep
 
-# Change this to a more secure secret key
-JWT_SECRET_KEY = 'secret_key'
+JWT_SECRET_KEY=''
 
 REDIS_CLOUD_HOST=
 REDIS_CLOUD_PORT=
 REDIS_CLOUD_PASSWORD=
+REDIS_DOCKER_URL=redis://redis:6379

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8000
+CMD ["node", "index.js"]

--- a/user-service/model/jwt-repository.js
+++ b/user-service/model/jwt-repository.js
@@ -3,16 +3,17 @@ import redis from 'redis';
 
 const EXPIRATION = 86400; // 24hrs
 
-const redisClientOptions =
-  process.env.ENV === 'PROD'
-    ? {
-        socket: {
-          host: process.env.REDIS_CLOUD_HOST,
-          port: process.env.REDIS_CLOUD_PORT,
-        },
-        password: process.env.REDIS_CLOUD_PASSWORD,
-      }
-    : {};
+const redisClientOptions = process.env.ENV === 'PROD'
+  ? {
+    socket: {
+      host: process.env.REDIS_CLOUD_HOST,
+      port: process.env.REDIS_CLOUD_PORT,
+    },
+    password: process.env.REDIS_CLOUD_PASSWORD,
+  }
+  : {
+    url: process.env.REDIS_DOCKER_URL
+  };
 
 const client = redis.createClient(redisClientOptions);
 

--- a/user-service/model/repository.js
+++ b/user-service/model/repository.js
@@ -5,11 +5,13 @@ import UserModel from './user-model.js';
 //Set up mongoose connection
 import mongoose from 'mongoose';
 
-let mongoDB = process.env.ENV == "PROD" ? process.env.DB_CLOUD_URI : process.env.DB_LOCAL_URI;
+const mongoDB = process.env.ENV == 'PROD' 
+  ? process.env.DB_CLOUD_URI 
+  : process.env.DB_LOCAL_URI || process.env.DB_DOCKER_URI;
 
 mongoose.connect(mongoDB, { useNewUrlParser: true , useUnifiedTopology: true});
 
-let db = mongoose.connection;
+const db = mongoose.connection;
 db.on('error', console.error.bind(console, 'MongoDB connection error:'));
 
 export async function createUser(params) { 


### PR DESCRIPTION
**Implementation Details**
- Instead of running `node index.js` for all microservices and `npm run start` for frontend separately, just run this ONE command - `docker-compose up` at the root directory, and you're good to go! 
- In fact, Redis Cloud and MongoDB Local or Cloud are not required anymore, but still able to be used, as they are substituted with Redis Docker and MongoDB Docker by default. 
- Also, with Docker volumes, even if you removed the containers or ran `docker-compose down`, your data is still able to persist!