### PR TITLE
Bug fix: Show UI after successful account update

### DIFF
--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -88,12 +88,9 @@ export async function updateAccount(req, res) {
       });
     }
 
-    if (await _updateAccount(username, newProfile)) {
-      // Authenticate updated user
-      const updatedUser = await authenticateUser(newUsername, newPassword);
-      if (!updatedUser) {
-          return res.status(401).json({ message: 'User does not exist and/or wrong password.' });
-      }
+    const updatedUser = await _updateAccount(username, newProfile);
+
+    if (updatedUser) {
       // Create new JWT for updated profile
       const token = _generateJwt(updatedUser);
       // Send cookie

--- a/user-service/model/repository.js
+++ b/user-service/model/repository.js
@@ -30,7 +30,7 @@ export async function getUserByEmail(email) {
 export async function updateAccountByUsername(username, newProfile) {
   return await UserModel.findOneAndUpdate({ username }, newProfile, {
     new: true,
-    rawResult: true, // Return the raw result from the MongoDB driver
+    returnDocument: "after" // return updated user object
   });
 }
 

--- a/user-service/model/user-orm.js
+++ b/user-service/model/user-orm.js
@@ -54,7 +54,12 @@ export async function ormUpdateAccount(username, newProfile) {
     newProfile.password = await bcrypt.hash(newProfile.password, saltRounds);
   }
   const updatedUser = await updateAccountByUsername(username, newProfile);
-  return updatedUser;
+  
+  // Check if the updated user is indeed updated
+  const usernameIsUpdated = !newProfile.username || (updatedUser.username === newProfile.username);
+  const passwordIsUpdated = !newProfile.password || (updatedUser.password === newProfile.password);
+
+  return usernameIsUpdated && passwordIsUpdated ? updatedUser : null;
 }
 
 // Returns true upon successful deletion

--- a/user-service/model/user-orm.js
+++ b/user-service/model/user-orm.js
@@ -48,13 +48,13 @@ export async function isExistingEmail(email) {
     return user ? true : false;
 }
 
-// Returns true upon successful update
+// Returns updated user object upon successful update, or null if update fails
 export async function ormUpdateAccount(username, newProfile) {
   if (newProfile.password) {
     newProfile.password = await bcrypt.hash(newProfile.password, saltRounds);
   }
-  const res = await updateAccountByUsername(username, newProfile);
-  return res.ok === 1;
+  const updatedUser = await updateAccountByUsername(username, newProfile);
+  return updatedUser;
 }
 
 // Returns true upon successful deletion


### PR DESCRIPTION
Steps to create the bug:
1. Update username or password
2. Username/password successfully change but does not navigate to homepage. Also, incorrect error message is shown.

Cause of the bug:
1. No username update or no password update (aka update 1 field only) fails the comparison with the user object in the database.

How to solve the bug:
1. Remove the redundant authenticate with updated user object. Since the underlying authenticate implementation is just check if the user exists using the username and check if the password matches, checking updatedUser === updatedUser is just redundant, so I removed it.
2. Add a sanity check to make sure that the return updated user indeed matches the field(s) to update.