### PR TITLE
Bug fix: update navbar upon signout

### DIFF
--- a/frontend/src/context/user-context.js
+++ b/frontend/src/context/user-context.js
@@ -75,7 +75,7 @@ export function UserContextProvider(props) {
       .post(URL_USER_SVC + LOGOUT_ENDPOINT, {}, { withCredentials: true })
       .then((res) => {
         const isSignoutSuccess = res && res.status === STATUS_CODE_OK;
-        setIsSignedIn(isSignoutSuccess);
+        setIsSignedIn(!isSignoutSuccess);
         return res.data;
       })
       .then((data) => {


### PR DESCRIPTION
Bug:
The navbar does not change after user signout

Cause of bug:
Upon successful signout, the `signoutHandler` in user context set the `isSignedIn` state to `true` while it should be **`false`**

Step to solve the bug:
set `isSignedIn` state in user context to `false` upon successful signout