### PR TITLE
Fix Bug (Matching Service): Cannot match the second time

### DIFF
--- a/frontend/src/pages/Match/index.js
+++ b/frontend/src/pages/Match/index.js
@@ -40,7 +40,6 @@ function MatchPage() {
   const difficulty = location.state?.difficulty;
 
   // Socket
-  const [room, setRoom] = useState('');
   const [isMatchFailed, setIsMatchFailed] = useState(false);
 
   // Timer
@@ -55,10 +54,13 @@ function MatchPage() {
     }
   }, [difficulty, navigate, alertCtx]);
 
-  // Register socket listeners
+  // Socket setup
   useEffect(() => {
+    // Register socket listeners
     socket.on('matchSuccess', (room) => {
-      setRoom(room);
+      if (difficulty) {
+        navigate('/room', { state: { room, difficulty } });
+      }
     });
     socket.on('matchFail', () => {
       setIsMatchFailed(true);
@@ -67,28 +69,23 @@ function MatchPage() {
       setIsMatchFailed(true);
     });
 
-    // Disconnect when unmount
-    return () => socket.disconnect();
-  }, []);
-
-  // Emit match event
-  useEffect(() => {
+     // Emit match event
     if (difficulty && userCtx.username) {
       socket.emit('match', {
         difficulty,
         username: userCtx.username,
       });
     }
-  }, [difficulty, userCtx]);
 
-  // Navigate to room page upon successful match
-  useEffect(() => {
-    if (room && difficulty) {
-      room && navigate('/room', { state: { room, difficulty } });
+    // Unregister listeners when unmount
+    return () => {
+      socket.off('matchSuccess');
+      socket.off('matchFail');
+      socket.off('disconnect');
     }
-  }, [room, difficulty, navigate]);
+  }, [difficulty, navigate, userCtx]);
 
-  // Timer
+  // Timer logic
   useEffect(() => {
     if (counter > 0) {
       setTimeout(() => setCounter(prevCounter => prevCounter - 1), 1000);


### PR DESCRIPTION
**Implementation Details**
- Disconnect from socket upon unmount caused second match to fail
- Instead of disconnecting from socket, just unregister listeners when unmount since listeners are re-registered upon mount