### PR TITLE
Add prefix for CRA environment variable

### DIFF
--- a/frontend/src/configs.js
+++ b/frontend/src/configs.js
@@ -1,5 +1,5 @@
 /////////////// Reverse Proxy ///////////////
-const URI_SVC = process.env.URI_SVC || 'http://localhost:8080';
+const URI_SVC = process.env.REACT_APP_URI_SVC || 'http://localhost:8080';
 
 /////////////// User Service ///////////////
 // API


### PR DESCRIPTION
https://create-react-app.dev/docs/adding-custom-environment-variables/

Based on the reference above, for create-react-app, the environment variable needs to be prefixed with `REACT_APP_`, except `NODE_ENV` which is predefined.