### PR TITLE
Fix Bug (Matching Service): Cancel Match instead of Disconnecting

### DIFF
--- a/frontend/src/pages/Match/index.js
+++ b/frontend/src/pages/Match/index.js
@@ -96,7 +96,7 @@ function MatchPage() {
 
   // Handlers
   const handleCancel = () => {
-    socket.disconnect();
+    socket.emit('cancelMatch', { id: socket.id });
     navigate('/home');
   };
   const handleRetry = () => {

--- a/matching-service/controller/matching-controller.js
+++ b/matching-service/controller/matching-controller.js
@@ -7,7 +7,7 @@ import {
 
 const MATCHING_TIME = 30000 // 30s
 
-export function handleMatch(socket) {
+export const handleMatch = (socket) => {
   socket.on('match', async (newMatch) => {
     // Check if there is already a pending match of same difficulty
     const pendingMatch = await _getPendingMatch(newMatch.difficulty, newMatch.username);
@@ -33,11 +33,17 @@ export function handleMatch(socket) {
       socket.emit('matchSuccess', pendingMatch.id);
     }
   });
-}
+};
 
-export function handleDisconnect(socket) {
+export const handleCancelMatch = (socket) => {
+  socket.on('cancelMatch', async () => {
+    await _deletePendingMatchById(socket.id);
+  });
+};
+
+export const handleDisconnect = (socket) => {
   socket.on('disconnect', async () => {
     await _deletePendingMatchById(socket.id);
     console.log(`User disconnected: ${socket.id}`);
   });
-}
+};

--- a/matching-service/index.js
+++ b/matching-service/index.js
@@ -3,7 +3,7 @@ import cors from 'cors';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 
-import { handleDisconnect, handleMatch } from './controller/matching-controller.js';
+import { handleMatch, handleCancelMatch, handleDisconnect } from './controller/matching-controller.js';
 
 const app = express();
 app.use(express.urlencoded({ extended: true }))
@@ -22,6 +22,7 @@ io.on('connection', (socket) => {
   console.log(`User connected: ${socket.id}`);
 
   handleMatch(socket);
+  handleCancelMatch(socket);
   handleDisconnect(socket);
 });
 


### PR DESCRIPTION
**Implementation Details**
- Due to previous changes, socket is disconnected when users cancel their match, which caused the bug
- Instead of disconnecting, frontend now emits a `cancelMatch` event
- Done some code refactoring also 